### PR TITLE
Update adduser syntax in laradock nginx setup

### DIFF
--- a/laradock/nginx/Dockerfile
+++ b/laradock/nginx/Dockerfile
@@ -15,7 +15,7 @@ RUN if [ ${CHANGE_SOURCE} = true ]; then \
 RUN apk update \
     && apk upgrade \
     && apk add --no-cache bash \
-    && adduser -D -H -u 1000 -s /bin/bash www-data
+    && adduser -D -H -u 1000 -s /bin/bash www-data -G www-data
 
 ARG PHP_UPSTREAM_CONTAINER=php-fpm
 ARG PHP_UPSTREAM_PORT=9000


### PR DESCRIPTION
Thanks for the great project!  When setting it up today, I needed this fix from laradock upstream to be able to build and start the containers.  Everything else worked fine.

```
Newer versions of adduser from busybox require -G to add a user to a
group that already exists, which www-data does.

See: https://github.com/laradock/laradock/issues/2160
```