### PR TITLE
Show proc rate modifier for items

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1091,6 +1091,7 @@ function return_item_stat_box($item, $show_name_icon)
         if ($item["proclevel2"] > 0) {
             $html_string .= "<br><b>Level for effect: </b>" . $item["proclevel2"];
         }
+        $html_string .= "<br><b>Effect chance modifier: </b>" . (100 + $item["procrate"]) . "%";
         $html_string .= "</td></tr>";
     }
     // worn effect


### PR DESCRIPTION
Howdy!  This was a request on my server, and after I figured out the basics of EQEmuAllakhazamClone and the procrate field, it was an easy addition.  I hope it's helpful.

```
100% is the base proc rate, corresponding to a 0 in an item's procrate
field.

Items with nonstandard proc rates range from -75 (25% normal rate) to
around 100 (200% rate) with some newer items at 500 and some that
"always" proc at 2600.

https://github.com/EQEmu/Server/blob/b938e6223c3e6766b8021e2efd274c3c004208b8/zone/attack.cpp#L4287-L4288
```

**Testing done:**

Short Sword of the Ykesha, with standard proc rate:
![ykesha](https://user-images.githubusercontent.com/13994/155607993-77eba767-0f17-41e5-89f1-ec4d426c82d1.png)

Howling Orb, with a low proc rate:
![howling-orb](https://user-images.githubusercontent.com/13994/155608037-eca8f2b2-1bc0-4d4d-8df2-a231063b5348.png)

Hierophant's Crook, with a higher proc rate:
![hierophants-crook](https://user-images.githubusercontent.com/13994/155608055-8212cbaf-c465-4fb5-84f8-e0130ea2ddd3.png)

A thrown item, Formed Suspension of Frost XIII, that's meant to proc:
![thrown](https://user-images.githubusercontent.com/13994/155608086-83cf1475-56de-4ac6-b52e-e29a5bcc14b9.png)

The highest proc rate I could find, out of curiosity; BER's Bore Axes of the Spirit:
![highest-bore-axes-of-the-spirit](https://user-images.githubusercontent.com/13994/155608147-43a4ffca-75cb-4394-9c33-430656ed6a82.png)

I also confirmed that several items types without procs were not affected.