### PR TITLE
Trim leading and trailing whitespace from searches

### DIFF
--- a/pages/global_search.php
+++ b/pages/global_search.php
@@ -1,5 +1,8 @@
 <?php
 
+// Trim whitespace from start and end of query; this works for direct entry and JS updates
+$_GET['q'] = trim($_GET['q']);
+
 $name = mysqli_real_escape_string($database, $_GET['q']);
 
 $page_title = "Global Search :: " . $_GET['q'];


### PR DESCRIPTION
People were having issues with search queries that they pasted in containing spaces at the end.  Spaces at the start and end don't seem meaningful, so this strips them out.

I tested that normal queries work OK, and that I can now search for "tiny dagger  " and still find the tiny dagger, can search for zones with explicit URLs like `?a=global_search&q=%20 the hive: sab` that have spaces at the beginning, can search for NPCs with spaces before, etc.  All seems well.