### PR TITLE
Improve display of spell details

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -887,6 +887,7 @@ $dbspellresists = [
     6 => "Chromatic",
     7 => "Prismatic",
     8 => "Physical",
+    9 => "Corruption",
 ];
 
 // Array of ALL races through VoA Expansion

--- a/includes/spell.inc.php
+++ b/includes/spell.inc.php
@@ -293,7 +293,7 @@ function SpellDescription($spell, $n, $csv = false)
                 break;
             case 121: // Reverse Damage Shield
                 $print_buffer .= $dbspelleffects[$spell["effectid$n"]];
-                $print_buffer .= " (-$max)";
+                $print_buffer .= " ($max)";
                 break;
             case 91: // Summon Corpse
                 $print_buffer .= $dbspelleffects[$spell["effectid$n"]];

--- a/includes/spell.inc.php
+++ b/includes/spell.inc.php
@@ -2,7 +2,7 @@
 
 function SpellDescription($spell, $n, $csv = false)
 {
-    global $dbspelleffects, $items_table, $dbiracenames, $spells_table, $server_max_level;
+    global $dbspelleffects, $dbspelltargets, $items_table, $dbiracenames, $spells_table, $server_max_level;
 
     $print_buffer = '<ul>';
 

--- a/includes/spell.inc.php
+++ b/includes/spell.inc.php
@@ -42,14 +42,14 @@ function SpellDescription($spell, $n, $csv = false)
                 if ($max < 0) { // Decrease
                     $print_buffer .= "Decrease Movement";
                     if ($min != $max) {
-                        $print_buffer .= " by " . abs($min) . "% (L$minlvl) to " . abs($max) . "% (L$maxlvl)";
+                        $print_buffer .= " by " . abs($min) . "% to " . abs($max) . "%";
                     } else {
                         $print_buffer .= " by " . abs(100) . "%";
                     }
                 } else {
                     $print_buffer .= "Increase Movement";
                     if ($min != $max) {
-                        $print_buffer .= " by " . $min . "% (L$minlvl) to " . ($max) . "% (L$maxlvl)";
+                        $print_buffer .= " by " . $min . "% to " . ($max) . "%";
                     } else {
                         $print_buffer .= " by " . ($max) . "%";
                     }
@@ -59,14 +59,14 @@ function SpellDescription($spell, $n, $csv = false)
                 if ($max < 100) { // Decrease
                     $print_buffer .= "Decrease Attack Speed";
                     if ($min != $max) {
-                        $print_buffer .= " by " . (100 - $min) . "% (L$minlvl) to " . (100 - $max) . "% (L$maxlvl)";
+                        $print_buffer .= " by " . (100 - $min) . "% to " . (100 - $max) . "%";
                     } else {
                         $print_buffer .= " by " . (100 - $max) . "%";
                     }
                 } else {
                     $print_buffer .= "Increase Attack Speed";
                     if ($min != $max) {
-                        $print_buffer .= " by " . ($min - 100) . "% (L$minlvl) to " . ($max - 100) . "% (L$maxlvl)";
+                        $print_buffer .= " by " . ($min - 100) . "% to " . ($max - 100) . "%";
                     } else {
                         $print_buffer .= " by " . ($max - 100) . "%";
                     }
@@ -130,7 +130,7 @@ function SpellDescription($spell, $n, $csv = false)
             case 294: // Increase Critical Spell Chance
                 $print_buffer .= $dbspelleffects[$spell["effectid$n"]];
                 if ($min != $max) {
-                    $print_buffer .= " by $min% (L$minlvl) to $max% (L$maxlvl)";
+                    $print_buffer .= " by $min% to $max%";
                 } else {
                     $print_buffer .= " by $max%";
                 }
@@ -139,9 +139,9 @@ function SpellDescription($spell, $n, $csv = false)
             case 100: // Increase Hitpoints v2 per tick
                 $print_buffer .= $dbspelleffects[$spell["effectid$n"]];
                 if ($min != $max) {
-                    $print_buffer .= " by " . abs($min) . " (L$minlvl) to " . abs(
+                    $print_buffer .= " by " . abs($min) . " to " . abs(
                             $max
-                        ) . " (L$maxlvl) per tick (total " . abs($min * $duration) . " to " . abs(
+                        ) . " per tick (total " . abs($min * $duration) . " to " . abs(
                                          $max * $duration
                                      ) . ")";
                 } else {
@@ -280,7 +280,7 @@ function SpellDescription($spell, $n, $csv = false)
                 }
                 $print_buffer .= $name;
                 if ($min != $max) {
-                    $print_buffer .= " by $min% (L$minlvl) to $max% (L$maxlvl)";
+                    $print_buffer .= " by $min% to $max%";
                 } else {
                     $print_buffer .= " by $max%";
                 }
@@ -400,7 +400,7 @@ function SpellDescription($spell, $n, $csv = false)
                 }
                 $print_buffer .= $name;
                 if ($min != $max) {
-                    $print_buffer .= " by $min (L$minlvl) to $max (L$maxlvl)";
+                    $print_buffer .= " by $min to $max";
                 } else {
                     if ($max < 0) {
                         $max = -$max;

--- a/includes/spell.inc.php
+++ b/includes/spell.inc.php
@@ -128,7 +128,27 @@ function SpellDescription($spell, $n, $csv = false)
             case 266: // Add Attack Chance
             case 273: // Increase Critical Dot Chance
             case 294: // Increase Critical Spell Chance
-                $print_buffer .= $dbspelleffects[$spell["effectid$n"]];
+                $name = $dbspelleffects[$spell["effectid$n"]];
+                // For several of these cases, we have better information on
+                // the range of values for the focus effect.
+                switch ($spell["effectid$n"]) {
+                    case 123: // Increase Spell Damage
+                    case 124: // Increase Spell Damage
+                    case 125: // Increase Spell Healing
+                    case 131: // Decrease Chance of Using Reagent
+                    case 132: // Decrease Spell Mana Cost
+                        $min = $spell["effect_base_value$n"];
+                        $max = $spell["effect_limit_value$n"];
+                        break;
+                    // Reword this effect to seem more natural, matching
+                    // Allakhazam.
+                    case 130: // Decrease Spell/Bash Hate
+                        $min = $spell["effect_base_value$n"];
+                        $max = $spell["effect_limit_value$n"];
+                        $name = str_replace("Decrease", "Increase", $name);
+                        break;
+                }
+                $print_buffer .= $name;
                 if ($min != $max) {
                     $print_buffer .= " by $min% to $max%";
                 } else {

--- a/pages/spells/spell.php
+++ b/pages/spells/spell.php
@@ -84,6 +84,18 @@ if ($dbspelltargets[$spell["targettype"]] != "") {
     $print_buffer .= "Unknown target (" . $spell["targettype"] . ")";
 }
 $print_buffer .= "</td></tr>";
+// AE range seems to be 1 for self/single-target spells
+if ($spell["aoerange"] > 1) {
+    $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>AoE Range</b></td><td>" . $spell["aoerange"] . "</td></tr>";
+}
+// AE max targets seems to be 1 for self/single-target spells
+if ($spell["aemaxtargets"] > 1) {
+    $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>AoE Max Targets</b></td><td>" . $spell["aemaxtargets"] . "</td></tr>";
+}
+// EQEmu server checks that duration >= 1000 before applying any AE rules
+if ($spell["AEDuration"] >= 1000) {
+    $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>AoE Duration</td><td>" . ($spell["AEDuration"] / 1000) . " sec</td></tr>";
+}
 $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Resist</b></td><td>" . $dbspellresists[$spell["resisttype"]];
 if ($spell["ResistDiff"] != 0) {
     $print_buffer .= " (adjust: " . $spell["ResistDiff"] . ")";

--- a/pages/spells/spell.php
+++ b/pages/spells/spell.php
@@ -82,6 +82,7 @@ if ($spell["ResistDiff"] != 0) {
     $print_buffer .= " (adjust: " . $spell["ResistDiff"] . ")";
 }
 $print_buffer .= "</td></tr>";
+$print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Interruptable</b></td><td>" . (($spell["uninterruptable"] == 0) ? "Yes" : "No") . "</td></tr>";
 if ($spell["TimeOfDay"] == 2) {
     $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Casting restriction</b></td><td>Nighttime</td></tr>";
 }

--- a/pages/spells/spell.php
+++ b/pages/spells/spell.php
@@ -77,7 +77,7 @@ if ($dbspelltargets[$spell["targettype"]] != "") {
     $print_buffer .= "Unknown target (" . $spell["targettype"] . ")";
 }
 $print_buffer .= "</td></tr>";
-$print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Resist</b></td><td>" . $dbspellresists[$spell["resist"]] . " (adjust: " . $spell["ResistDiff"] . ")</td></tr>";
+$print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Resist</b></td><td>" . $dbspellresists[$spell["resisttype"]] . " (adjust: " . $spell["ResistDiff"] . ")</td></tr>";
 if ($spell["TimeOfDay"] == 2) {
     $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Casting restriction</b></td><td>Nighttime</td></tr>";
 }

--- a/pages/spells/spell.php
+++ b/pages/spells/spell.php
@@ -70,6 +70,13 @@ $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Casti
 $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Recovery time</b></td><td>" . ($spell["recovery_time"] / 1000) . " sec</td></tr>";
 $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Recast time</b></td><td>" . ($spell["recast_time"] / 1000) . " sec</td></tr>";
 $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Range</b></td><td>" . $spell["range"] . "</td></tr>";
+// Adding these two fields seems to give the clearest picture.  Technically
+// HateAdded is modified for pets, dispel, and first hits, but those are
+// probably not the cases most people are looking for.
+$hate = $spell["HateAdded"] + $spell["bonushate"];
+if ($hate != 0) {
+    $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Hate Generated</b></td><td>$hate</td></tr>";
+}
 $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Target</b></td><td>";
 if ($dbspelltargets[$spell["targettype"]] != "") {
     $print_buffer .= $dbspelltargets[$spell["targettype"]];

--- a/pages/spells/spell.php
+++ b/pages/spells/spell.php
@@ -77,7 +77,11 @@ if ($dbspelltargets[$spell["targettype"]] != "") {
     $print_buffer .= "Unknown target (" . $spell["targettype"] . ")";
 }
 $print_buffer .= "</td></tr>";
-$print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Resist</b></td><td>" . $dbspellresists[$spell["resisttype"]] . " (adjust: " . $spell["ResistDiff"] . ")</td></tr>";
+$print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Resist</b></td><td>" . $dbspellresists[$spell["resisttype"]];
+if ($spell["ResistDiff"] != 0) {
+    $print_buffer .= " (adjust: " . $spell["ResistDiff"] . ")";
+}
+$print_buffer .= "</td></tr>";
 if ($spell["TimeOfDay"] == 2) {
     $print_buffer .= "<tr><td style='text-align:right; padding-right: 5px;'><b>Casting restriction</b></td><td>Nighttime</td></tr>";
 }


### PR DESCRIPTION
Here are a number of suggested improvements to the display of spells.  Below are descriptions of the individual commits with screenshots that demonstrate the changes.

---

```
    Add Corruption to resist type list
    
    http://docs.eqemu.io/server/spells/resist-types
```
Before, corruption resist was unknown:
![before-corruption-resist-crippling-terror](https://user-images.githubusercontent.com/13994/156681719-9a5e7923-4409-40e2-a3b5-c4ecbbb824d3.png)
After (and with a fix listed below) it shows:
![after-corruption-resist-crippling-terror](https://user-images.githubusercontent.com/13994/156681260-30873d6e-aae2-4d5e-889a-a872ea48237c.png)
(I just used a different color theme to accentuate the before/after difference.)

---

```
    Declare $dbspelltargets global to fix spell target limits
    
    Without this, the usage of $dbspelltargets in this function assumes it's
    a local, so it can't get the values from constants.php.  This fixes
    display of spell target limits, e.g. "Limit: Target (Giant excluded)"
```
Before, the `Target` entries were missing:
![before-spell-effects-improved-damage-2](https://user-images.githubusercontent.com/13994/156681399-26d9d876-ffdf-4560-a44c-bd46be9de1df.png)
After:
![after-spell-effects-improved-damage-2](https://user-images.githubusercontent.com/13994/156681424-64c6ba4a-da28-4c96-ba10-e62fc039d4ef.png)

---

```
    Fix display of reverse damage shield
    
    The database values are already negative, so this was inserting a second
    "-" before the number.
```
Before, double negative:
![before-reverse-damage-shield-single-negation](https://user-images.githubusercontent.com/13994/156681468-5d2deafc-f4e3-40cc-8f65-76e75c3eddfa.png)
After:
![after-reverse-damage-shield-single-negation](https://user-images.githubusercontent.com/13994/156681478-b409f95a-dc96-4459-9f84-39ee53097dce.png)

---

```
    Remove display of spell effect min/max levels
    
    $minlvl and $maxlvl are currently incorrect; $minlvl is taken to be the
    server's maximum character level, and $maxlvl is taken from the spell
    effect's effect_base_value, but the meaning of that field changes per
    effect.  This function could use reworking to pull the levels from
    appropriate places, and it seems best not to show data confusing users
    until then.
```
Before, the range didn't show up at all because min and max were the same.  So, let's look at it in combination with the next commit:
```
commit 0607fd0040f928e501283af2dfc567451ef9ffb6
Author: Tom Kirchner <git@halffull.org>
Date:   Thu Mar 3 16:01:34 2022 -0800

    Fix display of min/max spell effects for several effect types
    
    For example, this allows showing the range of effectiveness for the Improved
    Spell Damage focus, 1-20%, rather than just showing 1%.
    
    I checked peq data for each of the spell effects in this case list and
    found that several (spell damage, healing, etc.) have min and max effect
    values defined in effect_base_value and effect_limit_value, so it can be
    used to show the proper range; other effects just use effect_base_value,
    as used in the unchanged cases, with effect_limit_value being unused or
    used for a different purpose.
```
We already saw the fix for spell damage above, when talking about the missing `Target` entries.  Here are several other things it fixes:

Before, spell/bash hate was stuck at 1, and was described backwards, contradicting Allakhazam.  This is on Quivering Nightmares:
![before-increase-spell-bash-hate-quivering-nightmares](https://user-images.githubusercontent.com/13994/156681928-1864a58e-0758-4184-abd4-10779db15429.png)
After:
![after-increase-spell-bash-hate-quivering-nightmares](https://user-images.githubusercontent.com/13994/156681937-f5547e60-4c02-471c-af02-2db01094d2bd.png)
Before, mana preservation was stuck at 1:
![before-mana-preservation](https://user-images.githubusercontent.com/13994/156681959-3275dffc-f7b5-498b-9d74-0e000b61ef86.png)
After:
![after-mana-preservation](https://user-images.githubusercontent.com/13994/156681966-643d8046-e3cb-404c-ac84-928aae508a1d.png)
Before, reagent conservation was stuck at 1:
![before-reagent-conservation-4](https://user-images.githubusercontent.com/13994/156681987-6ba5be40-93f2-41e1-8d6f-d9d63a43c165.png)
After:
![after-reagent-conservation-4](https://user-images.githubusercontent.com/13994/156681992-6bb39ee8-5b82-4451-8415-2d91051f49b3.png)
Before, spell healing was stuck at 1:
![before-spell-healing-range](https://user-images.githubusercontent.com/13994/156682028-d51cc448-e030-4ab6-a9be-6d3a3205568a.png)
After:
![after-spell-healing-range](https://user-images.githubusercontent.com/13994/156682042-a4c5c6c0-5723-47f1-ac19-6a8b2576219e.png)

---

```
    Fix field name for retrieving spell resist type
```
We saw this at the top with corruption resist; the resist type wasn't showing at all because it was using the wrong field name.

---

```
    Only show spell resist adjustment if nonzero
```
Before, resist adjustment would show regardless; these are Ignite Blood and Smite:
![before-resist-type-ignite-blood-with-adjust](https://user-images.githubusercontent.com/13994/156682229-0c4d7ace-be2e-412c-b7f0-5f7f115a1fb2.png)
![before-resist-type-smite-no-adjust](https://user-images.githubusercontent.com/13994/156682237-08015373-94b3-4318-af1e-2be337bd5123.png)
After, it only shows if nonzero:
![after-resist-type-ignite-blood-with-adjust](https://user-images.githubusercontent.com/13994/156682247-2a75c717-0e42-430e-93ba-f4cf4cbc8237.png)
![after-resist-type-smite-no-adjust](https://user-images.githubusercontent.com/13994/156682259-8dda97b3-88d4-4bfc-b9e7-c26d5dfa1f74.png)

---

Finally, we add a few useful fields from the database.

```
    Show whether a spell is interruptable
```
Here's Greater Healing, interruptable:
![interruptable-yes-greater-healing](https://user-images.githubusercontent.com/13994/156682678-5d7275c8-8339-4c13-ab10-3863246fca49.png)
Here's Mana Beam, not interruptable:
![interruptable-no-mana-beam](https://user-images.githubusercontent.com/13994/156682699-6f505241-a2f5-4539-9abb-e4899cc010c2.png)

---

```
    Show additional hate generated by a spell, if any
```
Here's Tashania generating extra hate:
![hate-generated-tashania](https://user-images.githubusercontent.com/13994/156682850-e58dd6b0-fb72-4cd5-9fea-be9e8bb809fa.png)
Here's Pyromantic Ignition lowering hate:
![hate-generated-pyromantic-ignition](https://user-images.githubusercontent.com/13994/156682868-f1839cdc-e8c4-44ee-8360-492292ecb2d7.png)

---

```
    Add spell AoE range, max targets, and duration
```

Here's Fingers of Fire (PBAoE) showing AoE range:
![ae-range-fingers-of-fire](https://user-images.githubusercontent.com/13994/156682945-118edeee-767a-4067-a151-34c587da2575.png)
Here's Icestrike (targeted AoE) showing AoE duration:
![ae-duration-icestrike](https://user-images.githubusercontent.com/13994/156683025-374f7ba3-6f07-4a05-bdd1-d158187c4871.png)
Here's Blanket of Forgetfulness (targeted AoE) with a max number of targets:
![ae-max-targets-blanket-of-forgetfulness](https://user-images.githubusercontent.com/13994/156683106-e98191a4-abdd-48ea-9597-b5ed7b2eb815.png)