### PR TITLE
NPC: show proc spell and chance

### DIFF
--- a/pages/npcs/npc.php
+++ b/pages/npcs/npc.php
@@ -163,6 +163,19 @@ if ($npc["npc_spells_id"] > 0) {
     if (mysqli_num_rows($result) > 0) {
         $g = mysqli_fetch_array($result);
         $print_buffer .= "<td><table border='0'><tr><td colspan='2' nowrap='1'><h2 class='section_header'>This NPC casts the following spells</h2><p>";
+
+        // Show proc chance, which is just in npc_spells, not npc_spells_entries like the main spells below
+        if ($g["attack_proc"] > 0 ) {
+            $query = "SELECT id, name, new_icon FROM $spells_table WHERE id=" . $g["attack_proc"];
+            $result = db_mysql_query($query) or message_die('npc.php', 'MYSQL_QUERY', $query, mysqli_error());
+            if (mysqli_num_rows($result) > 0) {
+                $proc = mysqli_fetch_array($result);
+                $icon = '<img src="' . $icons_url . $proc['new_icon'] . '.gif" align="center" border="1" style="border-radius:5px;height:15px;width:auto">';
+                $print_buffer .= "<a href='?a=spell&id=" . $proc["id"] . "'>{$icon} {$proc['name']}</a>";
+                $print_buffer .= " (" . $g["proc_chance"] . "% proc)<br/><br/>";
+            }
+        }
+
         /** @noinspection SqlDialectInspection */
         $query = "
             SELECT
@@ -186,9 +199,6 @@ if ($npc["npc_spells_id"] > 0) {
             $print_buffer .= "</ul>{$list_name}";
             if ($DebugNpc) {
                 $print_buffer .= " (" . $npc["npc_spells_id"] . ")";
-            }
-            if ($g["attack_proc"] == 1) {
-                $print_buffer .= " (Procs)";
             }
             $print_buffer .= "<ul>";
             while ($row = mysqli_fetch_array($result2)) {


### PR DESCRIPTION
This adds a display of the spell an NPC can proc, and their chance to do so, if a proc is set.

The old code checked `attack_proc==1`, but `attack_proc` is the spell ID of a proc, and nothing is set to 1 in the peq database.

---

**Testing done:**

This first test case didn't change - an NPC with no spells at all, like scalebone skeleton:

![no-spells](https://user-images.githubusercontent.com/13994/158494865-c471459f-0989-477a-8e7e-77a72618d304.png)

---

Same here, no change if the mob has spells but no proc, like the ghoul lord:

![spells-no-proc-ghoul-lord](https://user-images.githubusercontent.com/13994/158494887-5725de25-9393-4e87-a975-4df9af6be5b8.png)

---

If a mob (like the lava basilisk here) has a proc but no spells, before you'd see an empty section:

![before-proc-no-spells-lava-basilisk](https://user-images.githubusercontent.com/13994/158494929-6648ea59-466a-4842-b95b-722da02ccb73.png)

After, you see the proc:

![after-proc-no-spells-lava-basilisk](https://user-images.githubusercontent.com/13994/158494942-afa7092a-4ddc-4bd0-9537-5e886677220c.png)

---

If a mob (like Manaetic Behemoth) has a proc and spells, before you'd just see the spells, and the proc wouldn't be included:

![before-proc-and-spells-manaetic-behemoth](https://user-images.githubusercontent.com/13994/158494993-641b8c97-e76d-460d-8617-013097e71051.png)

After, you see the proc and the spells:

![after-proc-and-spells-manaetic-behemoth](https://user-images.githubusercontent.com/13994/158495008-d31e2c31-863b-4a3f-bd25-70b8b83f9710.png)

(Note that the "Manaetic Behemoth" text in the middle is the name of the spell group, similar to "Default Pet Shadowknight List" for ghoul lord; it's not always unique to one mob.)